### PR TITLE
Set working copy as default configutarion of the execution

### DIFF
--- a/src/main/java/info/novatec/testit/livingdoc/intellij/gui/toolwindows/ToolWindowPanel.java
+++ b/src/main/java/info/novatec/testit/livingdoc/intellij/gui/toolwindows/ToolWindowPanel.java
@@ -273,6 +273,9 @@ public class ToolWindowPanel extends SimpleToolWindowPanel {
     private SpecificationNode convertDocumentNodeToLDNode(final DocumentNode childNode, final Node userObject) {
 
         SpecificationNode specificationNode = new SpecificationNode(childNode, userObject);
+        if (specificationNode.isCanBeImplemented()) {
+            specificationNode.setUsingCurrentVersion(true);
+        }
         specificationNode.setIcon(RepositoryViewUtils.getNodeIcon(specificationNode));
         return specificationNode;
     }

--- a/src/main/java/info/novatec/testit/livingdoc/intellij/gui/toolwindows/action/TagImplementedAction.java
+++ b/src/main/java/info/novatec/testit/livingdoc/intellij/gui/toolwindows/action/TagImplementedAction.java
@@ -40,7 +40,6 @@ public class TagImplementedAction extends AnAction {
 
     /**
      * Action handler.
-     * TODO NOTE: Basic functionality with single selection, desired multiple selection.
      *
      * @param anActionEvent Carries information on the invocation place
      */


### PR DESCRIPTION
With these changes, IntelliJ starts setting up the "working copy" as the default configuration of the execution.